### PR TITLE
ISCC commands lines can be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Pass your inno script in gulp src and pipe it to Inno.
 ```javascript
 var gulp = require('gulp');
 var inno = require('gulp-inno');
-gulp.src('./installer_script.iss').pipe(inno());
+gulp.src('./installer_script.iss')
+  .pipe(inno({
+    args: ['arg1', 'args2', 'arg3']
+  }));
 ```
 
 For OS X Users: If you get `Failed to start Cocoa app main loop`, you need to upgrade wine to the latest devel

--- a/index.js
+++ b/index.js
@@ -4,18 +4,18 @@ var path = require('path');
 
 module.exports = function(opts) {
   opts = opts || {};
+  opts.args = opts.args || [];
 
   return es.map(function(script, next) {
     var compil = path.resolve(path.join(__dirname, 'inno/ISCC.exe'));
     var script_path = path.resolve(script.path);
 
-    var args = opts.args || [];
-    var run;
+    var args, run;
     if (process.platform !== 'win32') {
-      args = args.concat([compil, 'Z:' + script_path]);
+      args = [compil, 'Z:' + script_path].concat(opts.args);
       run = spawn('wine', args);
     } else {
-      args = args.concat([script_path]);
+      args = [script_path].concat(opts.args);
       run = spawn(compil, args);
     }
     run.stdout.on('data', function(data) {

--- a/index.js
+++ b/index.js
@@ -3,16 +3,19 @@ var spawn = require('child_process').spawn;
 var path = require('path');
 
 module.exports = function(opts) {
+  opts = opts || {};
+
   return es.map(function(script, next) {
     var compil = path.resolve(path.join(__dirname, 'inno/ISCC.exe'));
     var script_path = path.resolve(script.path);
 
-    var args, run;
+    var args = opts.args || [];
+    var run;
     if (process.platform !== 'win32') {
-      args = [compil, 'Z:' + script_path];
+      args = args.concat([compil, 'Z:' + script_path]);
       run = spawn('wine', args);
     } else {
-      args = [script_path];
+      args = args.concat([script_path]);
       run = spawn(compil, args);
     }
     run.stdout.on('data', function(data) {


### PR DESCRIPTION
This commit will allow users to pass ISCC command lines like this:

``` javascript
inno({
    args: ['arg1', 'args2', 'arg3']
})
```
