### PR TITLE
Allow passing environment variables to iscc subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ var gulp = require('gulp');
 var inno = require('gulp-inno');
 gulp.src('./installer_script.iss')
   .pipe(inno({
-    args: ['arg1', 'args2', 'arg3']
+    args: ['arg1', 'args2', 'arg3'],
+    env: {
+        /* environment key-value pairs */
+    }
   }));
 ```
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var path = require('path');
 module.exports = function(opts) {
   opts = opts || {};
   opts.args = opts.args || [];
+  opts.env = opts.env || {};
 
   return es.map(function(script, next) {
     var compil = path.resolve(path.join(__dirname, 'inno/ISCC.exe'));
@@ -13,10 +14,10 @@ module.exports = function(opts) {
     var args, run;
     if (process.platform !== 'win32') {
       args = [compil, 'Z:' + script_path].concat(opts.args);
-      run = spawn('wine', args);
+      run = spawn('wine', args, {env: opts.env});
     } else {
       args = [script_path].concat(opts.args);
-      run = spawn(compil, args);
+      run = spawn(compil, args, {env: opts.env});
     }
     run.stdout.on('data', function(data) {
       console.log('stdout: ' + data);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 module.exports = function(opts) {
   opts = opts || {};
   opts.args = opts.args || [];
-  opts.env = opts.env || {};
+  opts.env = Object.assign({}, process.env, opts.env || {});
 
   return es.map(function(script, next) {
     var compil = path.resolve(path.join(__dirname, 'inno/ISCC.exe'));


### PR DESCRIPTION
Allow to pass environment variables to iscc subprocess like:
```
inno({
  env: {
    ENV_VAR: "value"
  }
})
```