### PR TITLE
cleaner logging with verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ gulp.src('./installer_script.iss')
     args: ['arg1', 'args2', 'arg3'],
     env: {
         /* environment key-value pairs */
-    }
+    },
+    verbose: true
   }));
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,18 @@
 var es = require('event-stream');
 var spawn = require('child_process').spawn;
 var path = require('path');
+var gutil = require('gulp-util');
 
 module.exports = function(opts) {
   opts = opts || {};
   opts.args = opts.args || [];
   opts.env = Object.assign({}, process.env, opts.env || {});
+
+  var log = function(){};  
+
+  if (!('verbose' in opts) || opts.verbose) {
+    log = gutil.log;
+  }
 
   return es.map(function(script, next) {
     var compil = path.resolve(path.join(__dirname, 'inno/ISCC.exe'));
@@ -20,14 +27,14 @@ module.exports = function(opts) {
       run = spawn(compil, args, {env: opts.env});
     }
     run.stdout.on('data', function(data) {
-      console.log('stdout: ' + data);
+      log('stdout: ' + data.toString().trim());
     });
     run.stderr.on('data', function(data) {
-      console.log('stderr: ' + data);
+      log('stderr: ' + data.toString().trim());
     });
     run.on('close', function(code) {
       var message = 'child process exited with code ' + code;
-      console.log(message);
+      gutil.log(message);
       if (code !== 0) {
         return next(message);
       } else {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Dustin Blackman",
   "license": "MIT",
   "dependencies": {
-    "event-stream": "3.3.1"
+    "event-stream": "3.3.1",
+    "gulp-util": "^3.0.8"
   }
 }


### PR DESCRIPTION
use `gulp-util` for output formatting and add a `verbose` option to disable logging (defaults to `true`, to preserve previous behavior, but `false` might be better...)